### PR TITLE
Fix problem with pyaudio overflows on OSX

### DIFF
--- a/audio spectrum_pt1_waveform_viewer.ipynb
+++ b/audio spectrum_pt1_waveform_viewer.ipynb
@@ -98,7 +98,7 @@
     "while True:\n",
     "    \n",
     "    # binary data\n",
-    "    data = stream.read(CHUNK)  \n",
+    "    data = stream.read(CHUNK, exception_on_overflow = False)\n",
     "    \n",
     "    # convert data to integers, make np array, then offset it by 127\n",
     "    data_int = struct.unpack(str(2 * CHUNK) + 'B', data)\n",

--- a/audio spectrum_pt2_spectrum_analyzer.ipynb
+++ b/audio spectrum_pt2_spectrum_analyzer.ipynb
@@ -112,7 +112,7 @@
     "while True:\n",
     "    \n",
     "    # binary data\n",
-    "    data = stream.read(CHUNK)    \n",
+    "    data = stream.read(CHUNK, exception_on_overflow = False)\n",
     "\n",
     "    data_np = np.frombuffer(data, dtype='h')\n",
     "    \n",


### PR DESCRIPTION
For some reason pyaudio on Mac OS X throws an exception
```
OSError                                   Traceback (most recent call last)
Cell In[2], [line 43](vscode-notebook-cell:?execution_count=2&line=43)
     [38](vscode-notebook-cell:?execution_count=2&line=38) start_time = time.time()
     [40](vscode-notebook-cell:?execution_count=2&line=40) while True:
     [41](vscode-notebook-cell:?execution_count=2&line=41)     
     [42](vscode-notebook-cell:?execution_count=2&line=42)     # binary data
---> [43](vscode-notebook-cell:?execution_count=2&line=43)     data = stream.read(CHUNK )
     [45](vscode-notebook-cell:?execution_count=2&line=45)     # convert data to integers, make np array, then offset it by 127
     [46](vscode-notebook-cell:?execution_count=2&line=46)     data_int = struct.unpack(str(2 * CHUNK) + 'B', data)

File [/opt/homebrew/lib/python3.12/site-packages/pyaudio/__init__.py:570](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/lib/python3.12/site-packages/pyaudio/__init__.py:570), in PyAudio.Stream.read(self, num_frames, exception_on_overflow)
    [567](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/lib/python3.12/site-packages/pyaudio/__init__.py:567) if not self._is_input:
    [568](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/lib/python3.12/site-packages/pyaudio/__init__.py:568)     raise IOError("Not input stream",
    [569](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/lib/python3.12/site-packages/pyaudio/__init__.py:569)                   paCanNotReadFromAnOutputOnlyStream)
--> [570](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/lib/python3.12/site-packages/pyaudio/__init__.py:570) return pa.read_stream(self._stream, num_frames,
    [571](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/lib/python3.12/site-packages/pyaudio/__init__.py:571)                       exception_on_overflow)

OSError: [Errno -9981] Input overflowed
```

Disable pyaudio exceptions completely. I haven't checked corner cases like real overflows on Linux, but seems this change is harmless.